### PR TITLE
Try To fix RPizeroW

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -511,7 +511,7 @@
       ifneq: (,$(filter arm%,$(MACHINE_TYPE)))
         copy:
           src: /usr/local/src/nexmon/patches/driver/brcmfmac_5.10.y-nexmon/brcmfmac.ko
-          dest: /lib/modules/5.10.103-v7+/kernel/drivers/net/wireless/broadcom/brcm80211/brcmfmac/brcmfmac.ko
+          dest: /lib/modules/5.10.103+/kernel/drivers/net/wireless/broadcom/brcm80211/brcmfmac/brcmfmac.ko
       else:    
         copy:
           src: /usr/local/src/nexmon/patches/driver/brcmfmac_5.10.y-nexmon/brcmfmac.ko

--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -438,15 +438,15 @@
       src: /usr/local/src/nexmon/patches/bcm43430a1/7_45_41_46/nexmon/brcmfmac43430-sdio.bin
       dest: /lib/firmware/brcm/brcmfmac43430-sdio.bin
 
-  - name: Delete the firmware blob to avoid it crashing
-    file:
-      state: absent
-      path: /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
+#  - name: Delete the firmware blob to avoid it crashing
+#    file:
+#      state: absent
+#      path: /lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
 
-  - name: Delete the RPiZW firmware blob to avoid it crashing
-    file:
-      state: absent
-      path: /lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-w.clm_blob
+#  - name: Delete the RPiZW firmware blob to avoid it crashing
+#    file:
+#      state: absent
+#      path: /lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-w.clm_blob
 
   - name: Delete the RPi3 firmware blob to avoid it crashing
     file:
@@ -508,9 +508,14 @@
   #     executable: /bin/bash
 
   - name: copy modified driver
-    copy:
-      src: /usr/local/src/nexmon/patches/driver/brcmfmac_5.10.y-nexmon/brcmfmac.ko
-      dest: /lib/modules/5.10.103-v7+/kernel/drivers/net/wireless/broadcom/brcm80211/brcmfmac/brcmfmac.ko
+      ifneq: (,$(filter arm%,$(MACHINE_TYPE)))
+        copy:
+          src: /usr/local/src/nexmon/patches/driver/brcmfmac_5.10.y-nexmon/brcmfmac.ko
+          dest: /lib/modules/5.10.103-v7+/kernel/drivers/net/wireless/broadcom/brcm80211/brcmfmac/brcmfmac.ko
+      else:    
+        copy:
+          src: /usr/local/src/nexmon/patches/driver/brcmfmac_5.10.y-nexmon/brcmfmac.ko
+          dest: /lib/modules/5.10.103-v7+/kernel/drivers/net/wireless/broadcom/brcm80211/brcmfmac/brcmfmac.ko
 
   - name: ensure depmod runs on reboot to load modified driver (brcmfmac)
     lineinfile:


### PR DESCRIPTION
Try To fix RPizeroW  changed to leave blob files as I think they are needed
Tried adding logic to identify RpizeroW and copy driver to correct location


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`

