### PR TITLE
Fixed issue24

### DIFF
--- a/pwnagotchi/plugins/__init__.py
+++ b/pwnagotchi/plugins/__init__.py
@@ -1,17 +1,17 @@
 import os
 import glob
-import _thread
 import threading
 import importlib, importlib.util
 import logging
-
-
+from concurrent.futures import ThreadPoolExecutor
 
 default_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "default")
 loaded = {}
 database = {}
 locks = {}
 
+THREAD_POOL_SIZE = 10
+executor = ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE)
 
 class Plugin:
     @classmethod
@@ -29,7 +29,6 @@ class Plugin:
                 cb = getattr(plugin_instance, attr_name, None)
                 if cb is not None and callable(cb):
                     locks["%s::%s" % (plugin_name, attr_name)] = threading.Lock()
-
 
 def toggle_plugin(name, enable=True):
     """
@@ -69,11 +68,9 @@ def toggle_plugin(name, enable=True):
 
     return False
 
-
 def on(event_name, *args, **kwargs):
     for plugin_name in loaded.keys():
         one(plugin_name, event_name, *args, **kwargs)
-
 
 def locked_cb(lock_name, cb, *args, **kwargs):
     global locks
@@ -83,7 +80,6 @@ def locked_cb(lock_name, cb, *args, **kwargs):
 
     with locks[lock_name]:
         cb(*args, *kwargs)
-
 
 def one(plugin_name, event_name, *args, **kwargs):
     global loaded
@@ -96,11 +92,10 @@ def one(plugin_name, event_name, *args, **kwargs):
             try:
                 lock_name = "%s::%s" % (plugin_name, cb_name)
                 locked_cb_args = (lock_name, callback, *args, *kwargs)
-                _thread.start_new_thread(locked_cb, locked_cb_args)
+                executor.submit(locked_cb, *locked_cb_args)
             except Exception as e:
                 logging.error("error while running %s.%s : %s" % (plugin_name, cb_name, e))
                 logging.error(e, exc_info=True)
-
 
 def load_from_file(filename):
     logging.debug("loading %s" % filename)
@@ -109,7 +104,6 @@ def load_from_file(filename):
     instance = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(instance)
     return plugin_name, instance
-
 
 def load_from_path(path, enabled=()):
     global loaded, database
@@ -125,7 +119,6 @@ def load_from_path(path, enabled=()):
                 logging.debug(e, exc_info=True)
 
     return loaded
-
 
 def load(config):
     enabled = [name for name, options in config['main']['plugins'].items() if

--- a/pwnagotchi/plugins/__init__.py
+++ b/pwnagotchi/plugins/__init__.py
@@ -138,3 +138,4 @@ def load(config):
 
     on('loaded')
     on('config_changed', config)
+


### PR DESCRIPTION
Fix the problem by adding a queue instead of an error message and restarting continuously

Thread Pooling for Plugin Event Callbacks in Pwnagotchi

## Description
Implemented a thread pooling mechanism for executing plugin event callbacks in the Pwnagotchi plugin management system (init.py). Instead of creating a new thread for each callback, a fixed number of worker threads are now utilized to execute queued tasks. This mitigates the "can't start new thread" error by limiting the number of concurrently running threads.

## Motivation and Context
The changes address the issue where the Pwnagotchi system throws a "can't start new thread" error due to excessive thread creation when handling multiple plugin event callbacks. Especially on devices with limited resources like the Raspberry Pi Zero, this can lead to system resource exhaustion. By using a thread pool, we ensure efficient use of threads, preventing resource overuse and the aforementioned error.

Link to the issue: https://github.com/aluminum-ice/pwnagotchi/issues/24
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
The modifications have been reviewed for syntactical accuracy, and the logic aligns with standard thread pooling implementations. 
Replaced the __init__.py file and deleted the cache file. Reboot the pwnagotchi and I did not received any error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`