### PR TITLE
add support for the v2 variant of the waveshare 2.7 inch display

### DIFF
--- a/pwnagotchi/ui/display.py
+++ b/pwnagotchi/ui/display.py
@@ -41,7 +41,10 @@ class Display(View):
         return self._implementation.name == 'waveshare_3'
 
     def is_waveshare27inch(self):
-        return self._implementation.name == 'waveshare27inch'
+        return self._implementation.name == 'waveshare27inch' or self._implementation.name == 'waveshare27inchv2'
+
+    def is_waveshare27inchv2(self):
+        return self._implementation.name == 'waveshare27inchv2'
 
     def is_waveshare29inch(self):
         return self._implementation.name == 'waveshare29inch'
@@ -69,7 +72,7 @@ class Display(View):
 
     def is_waveshare213bc(self):
         return self._implementation.name == 'waveshare213bc'
-    
+
     def is_waveshare213inb_v4(self):
         return self._implementation.name == 'waveshare213inb_v4'
 
@@ -78,7 +81,7 @@ class Display(View):
 
     def is_spotpear24inch(self):
         return self._implementation.name == 'spotpear24inch'
-    
+
     def is_displayhatmini(self):
         return self._implementation.name == 'displayhatmini'
 

--- a/pwnagotchi/ui/hw/__init__.py
+++ b/pwnagotchi/ui/hw/__init__.py
@@ -8,6 +8,7 @@ from pwnagotchi.ui.hw.waveshare1 import WaveshareV1
 from pwnagotchi.ui.hw.waveshare2 import WaveshareV2
 from pwnagotchi.ui.hw.waveshare3 import WaveshareV3
 from pwnagotchi.ui.hw.waveshare27inch import Waveshare27inch
+from pwnagotchi.ui.hw.waveshare27inchv2 import Waveshare27inchV2
 from pwnagotchi.ui.hw.waveshare29inch import Waveshare29inch
 from pwnagotchi.ui.hw.waveshare144lcd import Waveshare144lcd
 from pwnagotchi.ui.hw.waveshare154inch import Waveshare154inch
@@ -50,6 +51,9 @@ def display_for(config):
     elif config['ui']['display']['type'] == 'waveshare27inch':
         return Waveshare27inch(config)
 
+    elif config['ui']['display']['type'] == 'waveshare27inchv2':
+        return Waveshare27inchV2(config)
+
     elif config['ui']['display']['type'] == 'waveshare29inch':
         return Waveshare29inch(config)
 
@@ -73,6 +77,6 @@ def display_for(config):
 
     elif config['ui']['display']['type'] == 'spotpear24inch':
         return Spotpear24inch(config)
-    
+
     elif config['ui']['display']['type'] == 'displayhatmini':
         return DisplayHatMini(config)

--- a/pwnagotchi/ui/hw/libs/waveshare/v27inchv2/epd2in7_V2.py
+++ b/pwnagotchi/ui/hw/libs/waveshare/v27inchv2/epd2in7_V2.py
@@ -1,0 +1,519 @@
+# *****************************************************************************
+# * | File        :	  epd2in7_V2.py
+# * | Author      :   Waveshare team
+# * | Function    :   Electronic paper driver
+# * | Info        :
+# *----------------
+# * | This version:   V1.0
+# * | Date        :   2022-09-17
+# # | Info        :   python demo
+# -----------------------------------------------------------------------------
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documnetation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to  whom the Software is
+# furished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS OR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+from . import epdconfig
+
+# Display resolution
+EPD_WIDTH       = 176
+EPD_HEIGHT      = 264
+
+GRAY1  = 0xff #white
+GRAY2  = 0xC0
+GRAY3  = 0x80 #gray
+GRAY4  = 0x00 #Blackest
+
+logger = logging.getLogger(__name__)
+
+class EPD:
+    def __init__(self):
+        self.reset_pin = epdconfig.RST_PIN
+        self.dc_pin = epdconfig.DC_PIN
+        self.busy_pin = epdconfig.BUSY_PIN
+        self.cs_pin = epdconfig.CS_PIN
+        self.width = EPD_WIDTH
+        self.height = EPD_HEIGHT
+        self.GRAY1  = GRAY1 #white
+        self.GRAY2  = GRAY2
+        self.GRAY3  = GRAY3 #gray
+        self.GRAY4  = GRAY4 #Blackest
+
+    LUT_DATA_4Gray = [
+        0x40,0x48,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x8,0x48,0x10,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x2,0x48,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x20,0x48,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0xA,0x19,0x0,0x3,0x8,0x0,0x0,
+        0x14,0x1,0x0,0x14,0x1,0x0,0x3,
+        0xA,0x3,0x0,0x8,0x19,0x0,0x0,
+        0x1,0x0,0x0,0x0,0x0,0x0,0x1,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+        0x22,0x22,0x22,0x22,0x22,0x22,0x0,0x0,0x0,
+        0x22,0x17,0x41,0x0,0x32,0x1C,
+        ]
+
+    # Hardware reset
+    def reset(self):
+        epdconfig.digital_write(self.reset_pin, 1)
+        epdconfig.delay_ms(200)
+        epdconfig.digital_write(self.reset_pin, 0)
+        epdconfig.delay_ms(2)
+        epdconfig.digital_write(self.reset_pin, 1)
+        epdconfig.delay_ms(200)
+
+    def send_command(self, command):
+        epdconfig.digital_write(self.dc_pin, 0)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte([command])
+        epdconfig.digital_write(self.cs_pin, 1)
+
+    def send_data(self, data):
+        epdconfig.digital_write(self.dc_pin, 1)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte([data])
+        epdconfig.digital_write(self.cs_pin, 1)
+
+    def ReadBusy(self):
+        logger.debug("e-Paper busy")
+        while(epdconfig.digital_read(self.busy_pin) == 1):      #  1: idle, 0: busy
+            epdconfig.delay_ms(20)
+        logger.debug("e-Paper busy release")
+
+    def TurnOnDisplay(self):
+        self.send_command(0x22) #Display Update Control
+        self.send_data(0xF7)
+        self.send_command(0x20) #Activate Display Update Sequence
+        self.ReadBusy()
+
+    def TurnOnDisplay_Fast(self):
+        self.send_command(0x22) #Display Update Control
+        self.send_data(0xC7)
+        self.send_command(0x20) #Activate Display Update Sequence
+        self.ReadBusy()
+
+    def TurnOnDisplay_Partial(self):
+        self.send_command(0x22) #Display Update Control
+        self.send_data(0xFF)
+        self.send_command(0x20) #Activate Display Update Sequence
+        self.ReadBusy()
+
+    def TurnOnDisplay_4GRAY(self):
+        self.send_command(0x22) #Display Update Control
+        self.send_data(0xC7)
+        self.send_command(0x20) #Activate Display Update Sequence
+        self.ReadBusy()
+
+    def Lut(self):
+        self.send_command(0x32)
+        for i in range(159):
+            self.send_data(self.LUT_DATA_4Gray[i])
+
+    def init(self):
+        if (epdconfig.module_init() != 0):
+            return -1
+
+        # EPD hardware init start
+        self.reset()
+        self.ReadBusy()
+
+        self.send_command(0x12) #SWRESET
+        self.ReadBusy()
+
+        self.send_command(0x45) #set Ram-Y address start/end position
+        self.send_data(0x00)
+        self.send_data(0x00)
+        self.send_data(0x07) #0x0107-->(263+1)=264
+        self.send_data(0x01)
+
+        self.send_command(0x4F)   # set RAM y address count to 0;
+        self.send_data(0x00)
+        self.send_data(0x00)
+
+        self.send_command(0x11)  # data entry mode
+        self.send_data(0x03)
+        return 0
+
+    def init_Fast(self):
+        if (epdconfig.module_init() != 0):
+            return -1
+
+        # EPD hardware init start
+        self.reset()
+        self.ReadBusy()
+
+        self.send_command(0x12) #SWRESET
+        self.ReadBusy()
+
+        self.send_command(0x12) #SWRESET
+        self.ReadBusy()
+
+        self.send_command(0x18) #Read built-in temperature sensor
+        self.send_data(0x80)
+
+        self.send_command(0x22) # Load temperature value
+        self.send_data(0xB1)
+        self.send_command(0x20)
+        self.ReadBusy()
+
+        self.send_command(0x1A) # Write to temperature register
+        self.send_data(0x64)
+        self.send_data(0x00)
+
+        self.send_command(0x45) #set Ram-Y address start/end position
+        self.send_data(0x00)
+        self.send_data(0x00)
+        self.send_data(0x07) #0x0107-->(263+1)=264
+        self.send_data(0x01)
+
+        self.send_command(0x4F)   # set RAM y address count to 0;
+        self.send_data(0x00)
+        self.send_data(0x00)
+
+        self.send_command(0x11)   # data entry mode
+        self.send_data(0x03)
+
+        self.send_command(0x22) # Load temperature value
+        self.send_data(0x91)
+        self.send_command(0x20)
+        self.ReadBusy()
+        return 0
+
+    def Init_4Gray(self):
+        if (epdconfig.module_init() != 0):
+            return -1
+        self.reset()
+
+        self.send_command(0x12) # soft reset
+        self.ReadBusy();
+
+        self.send_command(0x74) #set analog block control
+        self.send_data(0x54)
+        self.send_command(0x7E) #set digital block control
+        self.send_data(0x3B)
+
+        self.send_command(0x01) #Driver output control
+        self.send_data(0x07)
+        self.send_data(0x01)
+        self.send_data(0x00)
+
+        self.send_command(0x11) #data entry mode
+        self.send_data(0x03)
+
+        self.send_command(0x44) #set Ram-X address start/end position
+        self.send_data(0x00)
+        self.send_data(0x15)   #0x15-->(21+1)*8=176
+
+        self.send_command(0x45) #set Ram-Y address start/end position
+        self.send_data(0x00)
+        self.send_data(0x00)
+        self.send_data(0x07) #0x0107-->(263+1)=264
+        self.send_data(0x01)
+
+
+        self.send_command(0x3C) #BorderWavefrom
+        self.send_data(0x00)
+
+
+        self.send_command(0x2C)     #VCOM Voltage
+        self.send_data(self.LUT_DATA_4Gray[158])    #0x1C
+
+
+        self.send_command(0x3F) #EOPQ
+        self.send_data(self.LUT_DATA_4Gray[153])
+
+        self.send_command(0x03) #VGH
+        self.send_data(self.LUT_DATA_4Gray[154])
+
+        self.send_command(0x04) #
+        self.send_data(self.LUT_DATA_4Gray[155]) #VSH1
+        self.send_data(self.LUT_DATA_4Gray[156]) #VSH2
+        self.send_data(self.LUT_DATA_4Gray[157]) #VSL
+
+        self.Lut() #LUT
+
+
+        self.send_command(0x4E)   # set RAM x address count to 0;
+        self.send_data(0x00)
+        self.send_command(0x4F)  # set RAM y address count to 0X199;
+        self.send_data(0x00)
+        self.send_data(0x00)
+        self.ReadBusy()
+        return 0
+
+    def getbuffer(self, image):
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
+        buf = [0xFF] * (int(self.width/8) * self.height)
+        image_monocolor = image.convert('1')
+        imwidth, imheight = image_monocolor.size
+        pixels = image_monocolor.load()
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        if(imwidth == self.width and imheight == self.height):
+            logger.debug("Vertical")
+            for y in range(imheight):
+                for x in range(imwidth):
+                    # Set the bits for the column of pixels at the current position.
+                    if pixels[x, y] == 0:
+                        buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
+        elif(imwidth == self.height and imheight == self.width):
+            logger.debug("Horizontal")
+            for y in range(imheight):
+                for x in range(imwidth):
+                    newx = y
+                    newy = self.height - x - 1
+                    if pixels[x, y] == 0:
+                        buf[int((newx + newy*self.width) / 8)] &= ~(0x80 >> (y % 8))
+        return buf
+
+    def getbuffer_4Gray(self, image):
+        # logger.debug("bufsiz = ",int(self.width/8) * self.height)
+        buf = [0xFF] * (int(self.width / 4) * self.height)
+        image_monocolor = image.convert('L')
+        imwidth, imheight = image_monocolor.size
+        pixels = image_monocolor.load()
+        i=0
+        # logger.debug("imwidth = %d, imheight = %d",imwidth,imheight)
+        if(imwidth == self.width and imheight == self.height):
+            logger.debug("Vertical")
+            for y in range(imheight):
+                for x in range(imwidth):
+                    # Set the bits for the column of pixels at the current position.
+                    if(pixels[x, y] == 0xC0):
+                        pixels[x, y] = 0x80
+                    elif (pixels[x, y] == 0x80):
+                        pixels[x, y] = 0x40
+                    i= i+1
+                    if(i%4 == 0):
+                        buf[int((x + (y * self.width))/4)] = ((pixels[x-3, y]&0xc0) | (pixels[x-2, y]&0xc0)>>2 | (pixels[x-1, y]&0xc0)>>4 | (pixels[x, y]&0xc0)>>6)
+
+        elif(imwidth == self.height and imheight == self.width):
+            logger.debug("Horizontal")
+            for x in range(imwidth):
+                for y in range(imheight):
+                    newx = y
+                    newy = self.height - x - 1
+                    if(pixels[x, y] == 0xC0):
+                        pixels[x, y] = 0x80
+                    elif (pixels[x, y] == 0x80):
+                        pixels[x, y] = 0x40
+                    i= i+1
+                    if(i%4 == 0):
+                        buf[int((newx + (newy * self.width))/4)] = ((pixels[x, y-3]&0xc0) | (pixels[x, y-2]&0xc0)>>2 | (pixels[x, y-1]&0xc0)>>4 | (pixels[x, y]&0xc0)>>6)
+        return buf
+
+    def Clear(self):
+        if(self.width % 8 == 0):
+            Width = self.width // 8
+        else:
+            Width = self.width // 8 +1
+        Height = self.height
+        self.send_command(0x24)
+        for j in range(Height):
+            for i in range(Width):
+                self.send_data(0XFF)
+        self.TurnOnDisplay()
+
+    def display(self, image):
+        if(self.width % 8 == 0):
+            Width = self.width // 8
+        else:
+            Width = self.width // 8 +1
+        Height = self.height
+        self.send_command(0x24)
+        for j in range(Height):
+            for i in range(Width):
+                self.send_data(image[i + j * Width])
+        self.TurnOnDisplay()
+
+    def display_Fast(self, image):
+        if(self.width % 8 == 0):
+            Width = self.width // 8
+        else:
+            Width = self.width // 8 +1
+        Height = self.height
+        self.send_command(0x24)
+        for j in range(Height):
+            for i in range(Width):
+                self.send_data(image[i + j * Width])
+        self.TurnOnDisplay_Fast()
+
+    def display_Base(self, image):
+        if(self.width % 8 == 0):
+            Width = self.width // 8
+        else:
+            Width = self.width // 8 +1
+        Height = self.height
+        self.send_command(0x24)   #Write Black and White image to RAM
+        for j in range(Height):
+            for i in range(Width):
+                self.send_data(image[i + j * Width])
+
+        self.send_command(0x26)  #Write Black and White image to RAM
+        for j in range(Height):
+            for i in range(Width):
+                self.send_data(image[i + j * Width])
+        self.TurnOnDisplay()
+
+    def display_Base_color(self, color):
+        if(self.width % 8 == 0):
+            Width = self.width // 8
+        else:
+            Width = self.width // 8 +1
+        Height = self.height
+        self.send_command(0x24)   #Write Black and White image to RAM
+        for j in range(Height):
+            for i in range(Width):
+                self.send_data(color)
+
+        self.send_command(0x26)  #Write Black and White image to RAM
+        for j in range(Height):
+            for i in range(Width):
+                self.send_data(color)
+        # self.TurnOnDisplay()
+
+    def display_Partial(self, Image, Xstart, Ystart, Xend, Yend):
+        if((Xstart % 8 + Xend % 8 == 8 & Xstart % 8 > Xend % 8) | Xstart % 8 + Xend % 8 == 0 | (Xend - Xstart)%8 == 0):
+            Xstart = Xstart // 8
+            Xend = Xend // 8
+        else:
+            Xstart = Xstart // 8
+            if Xend % 8 == 0:
+                Xend = Xend // 8
+            else:
+                Xend = Xend // 8 + 1
+
+        if(self.width % 8 == 0):
+            Width = self.width // 8
+        else:
+            Width = self.width // 8 +1
+        Height = self.height
+
+        Xend -= 1
+        Yend -= 1
+
+        # Reset
+        self.reset()
+
+        self.send_command(0x3C) #BorderWavefrom
+        self.send_data(0x80)
+
+        self.send_command(0x44)       # set RAM x address start/end, in page 35
+        self.send_data(Xstart & 0xff)    # RAM x address start at 00h;
+        self.send_data(Xend & 0xff)    # RAM x address end at 0fh(15+1)*8->128
+        self.send_command(0x45)       # set RAM y address start/end, in page 35
+        self.send_data(Ystart & 0xff)    # RAM y address start at 0127h;
+        self.send_data((Ystart>>8) & 0x01)    # RAM y address start at 0127h;
+        self.send_data(Yend & 0xff)    # RAM y address end at 00h;
+        self.send_data((Yend>>8) & 0x01)
+
+        self.send_command(0x4E)   # set RAM x address count to 0;
+        self.send_data(Xstart & 0xff)
+        self.send_command(0x4F)   # set RAM y address count to 0X127;
+        self.send_data(Ystart & 0xff)
+        self.send_data((Ystart>>8) & 0x01)
+
+        self.send_command(0x24)   #Write Black and White image to RAM
+        for j in range(Height):
+            for i in range(Width):
+                if((j > Ystart-1) & (j < (Yend + 1)) & (i > Xstart-1) & (i < (Xend + 1))):
+                    self.send_data(Image[i + j * Width])
+        self.TurnOnDisplay_Partial()
+
+    def display_4Gray(self, image):
+        self.send_command(0x24)
+        for i in range(0, 5808):                     #5808*4  46464
+            temp3=0
+            for j in range(0, 2):
+                temp1 = image[i*2+j]
+                for k in range(0, 2):
+                    temp2 = temp1&0xC0
+                    if(temp2 == 0xC0):
+                        temp3 |= 0x00
+                    elif(temp2 == 0x00):
+                        temp3 |= 0x01
+                    elif(temp2 == 0x80):
+                        temp3 |= 0x01
+                    else: #0x40
+                        temp3 |= 0x00
+                    temp3 <<= 1
+
+                    temp1 <<= 2
+                    temp2 = temp1&0xC0
+                    if(temp2 == 0xC0):
+                        temp3 |= 0x00
+                    elif(temp2 == 0x00):
+                        temp3 |= 0x01
+                    elif(temp2 == 0x80):
+                        temp3 |= 0x01
+                    else :   #0x40
+                        temp3 |= 0x00
+                    if(j!=1 or k!=1):
+                        temp3 <<= 1
+                    temp1 <<= 2
+            self.send_data(temp3)
+
+        self.send_command(0x26)
+        for i in range(0, 5808):                #5808*4  46464
+            temp3=0
+            for j in range(0, 2):
+                temp1 = image[i*2+j]
+                for k in range(0, 2):
+                    temp2 = temp1&0xC0
+                    if(temp2 == 0xC0):
+                        temp3 |= 0x00
+                    elif(temp2 == 0x00):
+                        temp3 |= 0x01
+                    elif(temp2 == 0x80):
+                        temp3 |= 0x00
+                    else: #0x40
+                        temp3 |= 0x01
+                    temp3 <<= 1
+
+                    temp1 <<= 2
+                    temp2 = temp1&0xC0
+                    if(temp2 == 0xC0):
+                        temp3 |= 0x00
+                    elif(temp2 == 0x00):
+                        temp3 |= 0x01
+                    elif(temp2 == 0x80):
+                        temp3 |= 0x00
+                    else:    #0x40
+                            temp3 |= 0x01
+                    if(j!=1 or k!=1):
+                        temp3 <<= 1
+                    temp1 <<= 2
+            self.send_data(temp3)
+
+        self.TurnOnDisplay_4GRAY()
+
+    def sleep(self):
+        self.send_command(0X10)
+        self.send_data(0x01)
+
+        epdconfig.delay_ms(2000)
+        epdconfig.module_exit()
+### END OF FILE ###
+

--- a/pwnagotchi/ui/hw/libs/waveshare/v27inchv2/epdconfig.py
+++ b/pwnagotchi/ui/hw/libs/waveshare/v27inchv2/epdconfig.py
@@ -1,0 +1,243 @@
+# /*****************************************************************************
+# * | File        :	  epdconfig.py
+# * | Author      :   Waveshare team
+# * | Function    :   Hardware underlying interface
+# * | Info        :
+# *----------------
+# * | This version:   V1.2
+# * | Date        :   2022-10-29
+# * | Info        :
+# ******************************************************************************
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documnetation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to  whom the Software is
+# furished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS OR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import os
+import logging
+import sys
+import time
+
+logger = logging.getLogger(__name__)
+
+
+class RaspberryPi:
+    # Pin definition
+    RST_PIN  = 17
+    DC_PIN   = 25
+    CS_PIN   = 8
+    BUSY_PIN = 24
+    PWR_PIN  = 18
+
+    def __init__(self):
+        import spidev
+        import RPi.GPIO
+
+        self.GPIO = RPi.GPIO
+        self.SPI = spidev.SpiDev()
+
+    def digital_write(self, pin, value):
+        self.GPIO.output(pin, value)
+
+    def digital_read(self, pin):
+        return self.GPIO.input(pin)
+
+    def delay_ms(self, delaytime):
+        time.sleep(delaytime / 1000.0)
+
+    def spi_writebyte(self, data):
+        self.SPI.writebytes(data)
+
+    def spi_writebyte2(self, data):
+        self.SPI.writebytes2(data)
+
+    def module_init(self):
+        self.GPIO.setmode(self.GPIO.BCM)
+        self.GPIO.setwarnings(False)
+        self.GPIO.setup(self.RST_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.DC_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.CS_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.PWR_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.BUSY_PIN, self.GPIO.IN)
+
+        self.GPIO.output(self.PWR_PIN, 1)
+
+        # SPI device, bus = 0, device = 0
+        self.SPI.open(0, 0)
+        self.SPI.max_speed_hz = 4000000
+        self.SPI.mode = 0b00
+        return 0
+
+    def module_exit(self):
+        logger.debug("spi end")
+        self.SPI.close()
+
+        logger.debug("close 5V, Module enters 0 power consumption ...")
+        self.GPIO.output(self.RST_PIN, 0)
+        self.GPIO.output(self.DC_PIN, 0)
+        self.GPIO.output(self.PWR_PIN, 0)
+
+        self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN, self.PWR_PIN])
+
+
+class JetsonNano:
+    # Pin definition
+    RST_PIN  = 17
+    DC_PIN   = 25
+    CS_PIN   = 8
+    BUSY_PIN = 24
+    PWR_PIN  = 18
+
+    def __init__(self):
+        import ctypes
+        find_dirs = [
+            os.path.dirname(os.path.realpath(__file__)),
+            '/usr/local/lib',
+            '/usr/lib',
+        ]
+        self.SPI = None
+        for find_dir in find_dirs:
+            so_filename = os.path.join(find_dir, 'sysfs_software_spi.so')
+            if os.path.exists(so_filename):
+                self.SPI = ctypes.cdll.LoadLibrary(so_filename)
+                break
+        if self.SPI is None:
+            raise RuntimeError('Cannot find sysfs_software_spi.so')
+
+        import Jetson.GPIO
+        self.GPIO = Jetson.GPIO
+
+    def digital_write(self, pin, value):
+        self.GPIO.output(pin, value)
+
+    def digital_read(self, pin):
+        return self.GPIO.input(self.BUSY_PIN)
+
+    def delay_ms(self, delaytime):
+        time.sleep(delaytime / 1000.0)
+
+    def spi_writebyte(self, data):
+        self.SPI.SYSFS_software_spi_transfer(data[0])
+
+    def spi_writebyte2(self, data):
+        for i in range(len(data)):
+            self.SPI.SYSFS_software_spi_transfer(data[i])
+
+    def module_init(self):
+        self.GPIO.setmode(self.GPIO.BCM)
+        self.GPIO.setwarnings(False)
+        self.GPIO.setup(self.RST_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.DC_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.CS_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.PWR_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.BUSY_PIN, self.GPIO.IN)
+
+        self.GPIO.output(self.PWR_PIN, 1)
+
+        self.SPI.SYSFS_software_spi_begin()
+        return 0
+
+    def module_exit(self):
+        logger.debug("spi end")
+        self.SPI.SYSFS_software_spi_end()
+
+        logger.debug("close 5V, Module enters 0 power consumption ...")
+        self.GPIO.output(self.RST_PIN, 0)
+        self.GPIO.output(self.DC_PIN, 0)
+        self.GPIO.output(self.PWR_PIN, 0)
+
+        self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN, self.PWR_PIN])
+
+
+class SunriseX3:
+    # Pin definition
+    RST_PIN  = 17
+    DC_PIN   = 25
+    CS_PIN   = 8
+    BUSY_PIN = 24
+    PWR_PIN  = 18
+    Flag     = 0
+
+    def __init__(self):
+        import spidev
+        import Hobot.GPIO
+
+        self.GPIO = Hobot.GPIO
+        self.SPI = spidev.SpiDev()
+
+    def digital_write(self, pin, value):
+        self.GPIO.output(pin, value)
+
+    def digital_read(self, pin):
+        return self.GPIO.input(pin)
+
+    def delay_ms(self, delaytime):
+        time.sleep(delaytime / 1000.0)
+
+    def spi_writebyte(self, data):
+        self.SPI.writebytes(data)
+
+    def spi_writebyte2(self, data):
+        # for i in range(len(data)):
+        #     self.SPI.writebytes([data[i]])
+        self.SPI.xfer3(data)
+
+    def module_init(self):
+        if self.Flag == 0:
+            self.Flag = 1
+            self.GPIO.setmode(self.GPIO.BCM)
+            self.GPIO.setwarnings(False)
+            self.GPIO.setup(self.RST_PIN, self.GPIO.OUT)
+            self.GPIO.setup(self.DC_PIN, self.GPIO.OUT)
+            self.GPIO.setup(self.CS_PIN, self.GPIO.OUT)
+            self.GPIO.setup(self.PWR_PIN, self.GPIO.OUT)
+            self.GPIO.setup(self.BUSY_PIN, self.GPIO.IN)
+
+            self.GPIO.output(self.PWR_PIN, 1)
+
+            # SPI device, bus = 0, device = 0
+            self.SPI.open(2, 0)
+            self.SPI.max_speed_hz = 4000000
+            self.SPI.mode = 0b00
+            return 0
+        else:
+            return 0
+
+    def module_exit(self):
+        logger.debug("spi end")
+        self.SPI.close()
+
+        logger.debug("close 5V, Module enters 0 power consumption ...")
+        self.Flag = 0
+        self.GPIO.output(self.RST_PIN, 0)
+        self.GPIO.output(self.DC_PIN, 0)
+        self.GPIO.output(self.PWR_PIN, 0)
+
+        self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
+
+
+if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
+    implementation = RaspberryPi()
+elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
+    implementation = SunriseX3()
+else:
+    implementation = JetsonNano()
+
+for func in [x for x in dir(implementation) if not x.startswith('_')]:
+    setattr(sys.modules[__name__], func, getattr(implementation, func))
+
+### END OF FILE ###

--- a/pwnagotchi/ui/hw/waveshare27inchv2.py
+++ b/pwnagotchi/ui/hw/waveshare27inchv2.py
@@ -1,0 +1,46 @@
+import logging
+
+import pwnagotchi.ui.fonts as fonts
+from pwnagotchi.ui.hw.base import DisplayImpl
+
+
+class Waveshare27inchV2(DisplayImpl):
+    def __init__(self, config):
+        super(Waveshare27inchV2, self).__init__(config, 'waveshare27inchv2')
+        self._display = None
+
+    def layout(self):
+        fonts.setup(10, 9, 10, 35, 25, 9)
+        self._layout['width'] = 264
+        self._layout['height'] = 176
+        self._layout['face'] = (66, 27)
+        self._layout['name'] = (5, 73)
+        self._layout['channel'] = (0, 0)
+        self._layout['aps'] = (28, 0)
+        self._layout['uptime'] = (199, 0)
+        self._layout['line1'] = [0, 14, 264, 14]
+        self._layout['line2'] = [0, 162, 264, 162]
+        self._layout['friend_face'] = (0, 146)
+        self._layout['friend_name'] = (40, 146)
+        self._layout['shakes'] = (0, 163)
+        self._layout['mode'] = (239, 163)
+        self._layout['status'] = {
+            'pos': (38, 93),
+            'font': fonts.status_font(fonts.Medium),
+            'max': 40
+        }
+        return self._layout
+
+    def initialize(self):
+        logging.info("initializing waveshare v2 2.7 inch display")
+        from pwnagotchi.ui.hw.libs.waveshare.v27inchv2.epd2in7_V2 import EPD
+        self._display = EPD()
+        self._display.init()
+        self._display.Clear()
+
+    def render(self, canvas):
+        buf = self._display.getbuffer(canvas)
+        self._display.display(buf)
+
+    def clear(self):
+        self._display.Clear()

--- a/pwnagotchi/utils.py
+++ b/pwnagotchi/utils.py
@@ -254,6 +254,9 @@ def load_config(args):
     elif config['ui']['display']['type'] in ('ws_27inch', 'ws27inch', 'waveshare_27inch', 'waveshare27inch'):
         config['ui']['display']['type'] = 'waveshare27inch'
 
+    elif config['ui']['display']['type'] in ('ws_27inchv2', 'ws27inchv2', 'waveshare_27inchv2', 'waveshare27inchv2'):
+        config['ui']['display']['type'] = 'waveshare27inchv2'
+
     elif config['ui']['display']['type'] in ('ws_29inch', 'ws29inch', 'waveshare_29inch', 'waveshare29inch'):
         config['ui']['display']['type'] = 'waveshare29inch'
 
@@ -277,7 +280,7 @@ def load_config(args):
 
     elif config['ui']['display']['type'] in ('ws_213bc', 'ws213bc', 'waveshare_213bc', 'waveshare213bc'):
         config['ui']['display']['type'] = 'waveshare213bc'
-    
+
     elif config['ui']['display']['type'] in ('ws_213bv4', 'ws213bv4', 'waveshare_213bv4', 'waveshare213inb_v4'):
         config['ui']['display']['type'] = 'waveshare213inb_v4'
 
@@ -286,10 +289,10 @@ def load_config(args):
 
     elif config['ui']['display']['type'] in ('spotpear24inch'):
         config['ui']['display']['type'] = 'spotpear24inch'
-    
+
     elif config['ui']['display']['type'] in ('displayhatmini'):
         config['ui']['display']['type'] = 'displayhatmini'
-        
+
     else:
         print("unsupported display type %s" % config['ui']['display']['type'])
         sys.exit(1)


### PR DESCRIPTION
Adds support for the V2 variant of the waveshare 2.7 inch display. This display uses a different library from the V1 display.

## Description
Includes updated display settings for the new display type.  All added files were taken from the source at https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7_V2.py

## Motivation and Context
The current code base supports v1 hardware which wasn't available on amazon. 

- [X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Deployed a full 1.7.8 deployment from SD card. Fixed issues that were preventing RPI4 to work in monitoring mode. Manually updated these files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
