### PR TITLE
Debug as var

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -18,6 +18,8 @@ main.whitelist = [
 ]
 main.filter = ""
 
+mail.log.debug = false
+
 main.plugins.grid.enabled = true
 main.plugins.grid.report = false
 main.plugins.grid.exclude = [

--- a/pwnagotchi/log.py
+++ b/pwnagotchi/log.py
@@ -221,7 +221,7 @@ def setup_logging(args, config):
     formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] %(message)s")
     root = logging.getLogger()
 
-    root.setLevel(logging.DEBUG if args.debug else logging.INFO)
+    root.setLevel(logging.DEBUG if args.debug or cfg['debug']==True else logging.INFO)
 
     if filename:
         # since python default log rotation might break session data in different files,


### PR DESCRIPTION
Allows simple user access to debug mode through webconfig. Modified log.py to include check for a new 'debug' setting on config.toml. 

## Description
in log.py: root.setLevel(logging.DEBUG if args.debug or cfg['debug'] == True else logging.INFO
in default.toml: main.log.debug = false

## Motivation and Context
For less tech savvy users who want to contribute, simplifies the process for enabling debug mode on pwnagotchi.


## How Has This Been Tested?
successfully tested on existing 1.7.8 build with latest bettercap.py changes incorporated.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.