### PR TITLE
add delay between bettercap and pwnagotchi starts

### DIFF
--- a/pwnagotchi/__init__.py
+++ b/pwnagotchi/__init__.py
@@ -133,6 +133,7 @@ def restart(mode):
         os.system("touch /root/.pwnagotchi-manual")
 
     os.system("service bettercap restart")
+    time.sleep(2)
     os.system("service pwnagotchi restart")
 
 


### PR DESCRIPTION
Add a delay as a temporary fix to a race condition between these two services starting

## Description
Adds a 2 second sleep before pwnagotchi service starts, to delay deletion of the startup mode override file. 

## Motivation and Context
This is a temporary fix to issue #61 so that the manual mode caplet runs when appropriate.   

- [ X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
- Tested manually on a Pi Zero 2W with wifi chipset version 1. 
- Tested with v1.7.9 and v.1.8.0 releases

To test:
- Initiate a bluetooth tether to the pwnagotchi with no USB or ethernet connected. 
- Tail daemon.log to observe the ip address that the Bettercap service comes up on. 
- Toggle between manual and auto modes with the web ui.
- Expect 127.0.0.1 when in auto mode and 0.0.0.0 when in manual. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ X] I have signed-off my commits with `git commit -s`
