### PR TITLE
give plugins access to all raw bettercap events

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -324,6 +324,12 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         found_handshake = False
         jmsg = json.loads(msg)
 
+        # give plugins access to all raw bettercap events
+        try:
+            plugins.on('bcap_%s' % re.sub(r"[^a-z0-9_]+", "_",  jmsg['tag'].lower()), self, jmsg)
+        except Exception as err:
+            logging.error("Processing event: %s" % err)
+
         if jmsg['tag'] == 'wifi.client.handshake':
             filename = jmsg['data']['file']
             sta_mac = jmsg['data']['station']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Calls the on_ handlers for plugins for all raw bettercap events.  BLE, HID, GPS, WIFI, etc.

## Description
<!--- Describe your changes in detail -->
Added changes to the bettercap event handler to pass on to plugins

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This makes plugins more capable, allowing them to respond to pretty much anything.
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested for months on pwnagotchi with ble monitor plugin, gps plugins, syslog monitoring plugins.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ X] I have signed-off my commits with `git commit -s`
