### PR TITLE
added support for PWM backlight to displayhatmini

### DIFF
--- a/pwnagotchi/ui/hw/displayhatmini.py
+++ b/pwnagotchi/ui/hw/displayhatmini.py
@@ -42,3 +42,11 @@ class DisplayHatMini(DisplayImpl):
 
     def clear(self):
         self._display.clear()
+
+    def set_backlight(self, value):
+        if self._display:
+            self._display.set_backlight(value)
+
+    def get_backlight(self):
+        if self._display:
+            self._display.get_backlight(value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Backlight PWM (variable brightness) for display hat mini
## Description
<!--- Describe your changes in detail -->
Support for PWM modulation of backlight on display hat mini.  requires rpi-hardware-pwm package (sudo pip3 install rpi-hardware-pwm).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

The backlight for the display is very bright, but the hardware supports dimming. Dim display is better in some cases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on various pwnagotchis with displays.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
