### PR TITLE
allow session() to fetch just a section of info

### DIFF
--- a/pwnagotchi/bettercap.py
+++ b/pwnagotchi/bettercap.py
@@ -31,8 +31,10 @@ class Client(object):
         self.websocket = "ws://%s:%s@%s:%d/api" % (username, password, hostname, port)
         self.auth = HTTPBasicAuth(username, password)
 
-    def session(self):
-        r = requests.get("%s/session" % self.url, auth=self.auth)
+    # session takes optional argument to pull a sub-dictionary
+    #  ex.: "session/wifi", "session/ble"
+    def session(self, sess="session"):
+        r = requests.get("%s/%s" % (self.url, sess), auth=self.auth)
         return decode(r)
 
     async def start_websocket(self, consumer):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed session() call to have an optional parameter to specify a
sub-section of the session information. Not all subsections
seem to be supported by bettercap, but wifi, ble and hid are.  gps is not,
but is part of the complete session. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

Reduces data transferred from bettercap to pwnagotchi when only
one section is needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested running on various pwnagotchi.  Used in Snifflupagus/pwnagotchi-utils 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
