### PR TITLE
WPA-SEC multiple improvements

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -49,6 +49,7 @@ main.plugins.wpa-sec.enabled = false
 main.plugins.wpa-sec.api_key = ""
 main.plugins.wpa-sec.api_url = "https://wpa-sec.stanev.org"
 main.plugins.wpa-sec.download_results = false
+main.plugins.wpa-sec.single_files = false
 main.plugins.wpa-sec.download_interval = 3600
 main.plugins.wpa-sec.whitelist = []
 

--- a/pwnagotchi/plugins/default/wpa-sec.py
+++ b/pwnagotchi/plugins/default/wpa-sec.py
@@ -1,94 +1,80 @@
-import os
 import logging
+import os
+import re
 import requests
+import sqlite3
 from datetime import datetime
-from threading import Lock
-from pwnagotchi.utils import StatusFile, remove_whitelisted
+from enum import Enum
 from pwnagotchi import plugins
-from json.decoder import JSONDecodeError
-
+from pwnagotchi.utils import remove_whitelisted
+from threading import Lock
 
 class WpaSec(plugins.Plugin):
     __author__ = '33197631+dadav@users.noreply.github.com'
     __version__ = '2.1.0'
     __license__ = 'GPL3'
     __description__ = 'This plugin automatically uploads handshakes to https://wpa-sec.stanev.org'
+    
+    class Status(Enum):
+        TOUPLOAD = 0
+        INVALID = 1
+        SUCCESSFULL = 2
 
     def __init__(self):
         self.ready = False
         self.lock = Lock()
-        try:
-            self.report = StatusFile('/root/.wpa_sec_uploads', data_format='json')
-        except JSONDecodeError:
-            os.remove("/root/.wpa_sec_uploads")
-            self.report = StatusFile('/root/.wpa_sec_uploads', data_format='json')
+        
         self.options = dict()
-        self.skip = list()
-
-    def _upload_to_wpasec(self, path, timeout=30):
-        """
-        Uploads the file to https://wpa-sec.stanev.org, or another endpoint.
-        """
-        with open(path, 'rb') as file_to_upload:
-            cookie = {'key': self.options['api_key']}
-            payload = {'file': file_to_upload}
-
-            try:
-                result = requests.post(self.options['api_url'],
-                                       cookies=cookie,
-                                       files=payload,
-                                       timeout=timeout)
-                if ' already submitted' in result.text:
-                    logging.debug("%s was already submitted.", path)
-            except requests.exceptions.RequestException as req_e:
-                raise req_e
-
-
-    def _download_from_wpasec(self, output, timeout=30):
-        """
-        Downloads the results from wpasec and safes them to output
-
-        Output-Format: bssid, station_mac, ssid, password
-        """
-        api_url = self.options['api_url']
-        if not api_url.endswith('/'):
-            api_url = f"{api_url}/"
-        api_url = f"{api_url}?api&dl=1"
-
-        cookie = {'key': self.options['api_key']}
-        try:
-            result = requests.get(api_url, cookies=cookie, timeout=timeout)
-            with open(output, 'wb') as output_file:
-                output_file.write(result.content)
-        except requests.exceptions.RequestException as req_e:
-            raise req_e
-        except OSError as os_e:
-            raise os_e
-
+        
+        self._init_db()
+        
+    def _init_db(self):
+        db_conn = sqlite3.connect('/root/.wpa_sec_db')
+        db_conn.execute('pragma journal_mode=wal')
+        with db_conn:
+            db_conn.execute('''
+                CREATE TABLE IF NOT EXISTS handshakes (
+                    path TEXT PRIMARY KEY,
+                    status INTEGER
+                )
+            ''')
+            db_conn.execute('''
+                CREATE INDEX IF NOT EXISTS idx_handshakes_status
+                ON handshakes (status)
+            ''')
+        db_conn.close()
 
     def on_loaded(self):
         """
         Gets called when the plugin gets loaded
         """
         if 'api_key' not in self.options or ('api_key' in self.options and not self.options['api_key']):
-            logging.error("WPA_SEC: API-KEY isn't set. Can't upload to wpa-sec.stanev.org")
+            logging.error("WPA_SEC: API-KEY isn't set. Can't upload.")
             return
 
         if 'api_url' not in self.options or ('api_url' in self.options and not self.options['api_url']):
-            logging.error("WPA_SEC: API-URL isn't set. Can't upload, no endpoint configured.")
+            logging.error("WPA_SEC: API-URL isn't set. Can't upload.")
             return
 
-        if 'whitelist' not in self.options:
-            self.options['whitelist'] = list()
+        self.skip_until_reload = set()
 
         self.ready = True
-        logging.info("WPA_SEC: plugin loaded")
-
-    def on_webhook(self, path, request):
-        from flask import make_response, redirect
-        response = make_response(redirect(self.options['api_url'], code=302))
-        response.set_cookie('key', self.options['api_key'])
-        return response
+        logging.info("WPA_SEC: plugin loaded.")
+        
+    def on_handshake(self, agent, filename, access_point, client_station):
+        whitelist = self.options.get('whitelist', list())
+        if not remove_whitelisted([filename], whitelist):
+            return
+        
+        db_conn = sqlite3.connect('/root/.wpa_sec_db')
+        with db_conn:
+            db_conn.execute('''
+                INSERT INTO handshakes (path, status)
+                VALUES (?, ?)
+                ON CONFLICT(path) DO UPDATE SET status = excluded.status
+                WHERE handshakes.status = ?
+            ''', (filename, self.Status.TOUPLOAD.value, self.Status.INVALID.value))
+        db_conn.close()
 
     def on_internet_available(self, agent):
         """
@@ -98,47 +84,158 @@ class WpaSec(plugins.Plugin):
             return
 
         with self.lock:
-            config = agent.config()
             display = agent.view()
-            reported = self.report.data_field_or('reported', default=list())
-            handshake_dir = config['bettercap']['handshakes']
-            handshake_filenames = os.listdir(handshake_dir)
-            handshake_paths = [os.path.join(handshake_dir, filename) for filename in handshake_filenames if
-                               filename.endswith('.pcap')]
-            handshake_paths = remove_whitelisted(handshake_paths, self.options['whitelist'])
-            handshake_new = set(handshake_paths) - set(reported) - set(self.skip)
+            
+            try:
+                db_conn = sqlite3.connect('/root/.wpa_sec_db')
+                cursor = db_conn.cursor()
+                
+                cursor.execute('SELECT path FROM handshakes WHERE status = ?', (self.Status.TOUPLOAD.value,))
+                handshakes_toupload = [row[0] for row in cursor.fetchall()]
+                handshakes_toupload = set(handshakes_toupload) - self.skip_until_reload
 
-            if handshake_new:
-                logging.info("WPA_SEC: Internet connectivity detected. Uploading new handshakes to wpa-sec.stanev.org")
-                for idx, handshake in enumerate(handshake_new):
-                    display.on_uploading(f"wpa-sec.stanev.org ({idx + 1}/{len(handshake_new)})")
+                if handshakes_toupload:
+                    logging.info("WPA_SEC: Internet connectivity detected. Uploading new handshakes...")
+                    for idx, handshake in enumerate(handshakes_toupload):
+                        display.on_uploading(f"WPA-SEC ({idx + 1}/{len(handshakes_toupload)})")
+                        logging.info("WPA_SEC: Uploading %s...", handshake)
 
-                    try:
-                        self._upload_to_wpasec(handshake)
-                        reported.append(handshake)
-                        self.report.update(data={'reported': reported})
-                        logging.debug("WPA_SEC: Successfully uploaded %s", handshake)
-                    except requests.exceptions.RequestException as req_e:
-                        self.skip.append(handshake)
-                        logging.debug("WPA_SEC: %s", req_e)
-                        continue
-                    except OSError as os_e:
-                        logging.debug("WPA_SEC: %s", os_e)
-                        continue
+                        try:
+                            upload_response = self._upload_to_wpasec(handshake)
+                            
+                            if upload_response.startswith("hcxpcapngtool"):
+                                logging.info(f"WPA_SEC: {handshake} successfully uploaded.")
+                                new_status = self.Status.SUCCESSFULL.value
+                            else:
+                                logging.info(f"WPA_SEC: {handshake} uploaded, but it was invalid.")
+                                new_status = self.Status.INVALID.value
 
-                display.on_normal()
+                            cursor.execute('''
+                                INSERT INTO handshakes (path, status)
+                                VALUES (?, ?)
+                                ON CONFLICT(path) DO UPDATE SET status = excluded.status
+                            ''', (handshake, new_status))
+                            db_conn.commit()
+                            
+                        except requests.exceptions.RequestException:
+                            logging.exception("WPA_SEC: RequestException uploading %s, skipping until reload.", handshake)
+                            self.skip_until_reload.append(handshake)
+                        except OSError:
+                            logging.exception("WPA_SEC: OSError uploading %s, deleting from db.", handshake)
+                            cursor.execute('DELETE FROM handshakes WHERE path = ?', (handshake,))
+                            db_conn.commit()
+                        except Exception:
+                            logging.exception("WPA_SEC: Exception uploading %s.", handshake)
 
-            if 'download_results' in self.options and self.options['download_results']:
-                cracked_file = os.path.join(handshake_dir, 'wpa-sec.cracked.potfile')
-                if os.path.exists(cracked_file):
-                    last_check = datetime.fromtimestamp(os.path.getmtime(cracked_file))
-                    download_interval = int(self.options['download_interval'])
-                    if last_check is not None and ((datetime.now() - last_check).seconds / download_interval) < 1:
-                        return
+                    display.on_normal()
+                    
+                cursor.close()
+                db_conn.close()
+            except Exception:
+                logging.exception("WPA_SEC: Exception uploading results.")
+
+            try:
+                if 'download_results' in self.options and self.options['download_results']:
+                    config = agent.config()
+                    handshake_dir = config['bettercap']['handshakes']
+                    
+                    cracked_file_path = os.path.join(handshake_dir, 'wpa-sec.cracked.potfile')
+
+                    if os.path.exists(cracked_file_path):
+                        last_check = datetime.fromtimestamp(os.path.getmtime(cracked_file_path))
+                        download_interval = int(self.options.get('download_interval', 3600))
+                        if last_check is not None and ((datetime.now() - last_check).seconds / download_interval) < 1:
+                            return
+
+                    self._download_from_wpasec(cracked_file_path)
+                    if 'single_files' in self.options and self.options['single_files']:
+                        self._write_cracked_single_files(cracked_file_path, handshake_dir)
+            except Exception:
+                logging.exception("WPA_SEC: Exception downloading results.")
+
+    def _upload_to_wpasec(self, path, timeout=30):
+        """
+        Uploads the file to wpasec
+        """
+        with open(path, 'rb') as file_to_upload:
+            cookie = {'key': self.options['api_key']}
+            payload = {'file': file_to_upload}
+
+            result = requests.post(
+                self.options['api_url'],
+                cookies=cookie,
+                files=payload,
+                timeout=timeout
+            )
+            result.raise_for_status()
+            
+            response = result.text.partition('\n')[0]
+            
+            logging.debug("WPA_SEC: Response uploading %s: %s.", path, response)
+            
+            return response
+
+    def _download_from_wpasec(self, output, timeout=30):
+        """
+        Downloads the results from wpasec and saves them to output
+
+        Output-Format: bssid, station_mac, ssid, password
+        """
+        api_url = self.options['api_url']
+        if not api_url.endswith('/'):
+            api_url = f"{api_url}/"
+        api_url = f"{api_url}?api&dl=1"
+
+        cookie = {'key': self.options['api_key']}
+
+        logging.info("WPA_SEC: Downloading cracked passwords...")
+
+        result = requests.get(api_url, cookies=cookie, timeout=timeout)
+        result.raise_for_status()
+
+        with open(output, 'wb') as output_file:
+            output_file.write(result.content)
+
+        logging.info("WPA_SEC: Downloaded cracked passwords.")
+
+    def _write_cracked_single_files(self, cracked_file_path, handshake_dir):
+        """
+        Splits download results from wpasec into individual .pcap..cracked files in handshake_dir
+
+        Each .pcap.cracked file will contain the cracked handshake password
+        """
+        logging.info("WPA_SEC: Writing cracked single files...")
+
+        with open(cracked_file_path, 'r') as cracked_file:
+            for line in cracked_file:
                 try:
-                    self._download_from_wpasec(os.path.join(handshake_dir, 'wpa-sec.cracked.potfile'))
-                    logging.info("WPA_SEC: Downloaded cracked passwords.")
-                except requests.exceptions.RequestException as req_e:
-                    logging.debug("WPA_SEC: %s", req_e)
-                except OSError as os_e:
-                    logging.debug("WPA_SEC: %s", os_e)
+                    bssid,station_mac,ssid,password = line.split(":")
+                    if password:
+                        handshake_filename = re.sub(r'[^a-zA-Z0-9]', '', ssid) + '_' + bssid
+                        pcap_path = os.path.join(handshake_dir, handshake_filename+'.pcap')
+                        pcap_cracked_path = os.path.join(handshake_dir, handshake_filename+'.pcap.cracked')
+                        if os.path.exists(pcap_path) and not os.path.exists(pcap_cracked_path):
+                            with open(pcap_cracked_path, 'w') as f:
+                                f.write(password)
+                except Exception:
+                    logging.exception(f"WPA_SEC: Exception writing cracked single file, parsing line {line}.")
+    
+        logging.info("WPA_SEC: Wrote cracked single files.")
+
+    def on_webhook(self, path, request):
+        from flask import make_response
+        
+        html_content = f'''
+            <html>
+                <body>
+                    <form id="postForm" action="{self.options['api_url']}" method="POST">
+                        <input type="hidden" name="key" value="{self.options['api_key']}">
+                    </form>
+                    <script type="text/javascript">
+                        document.getElementById('postForm').submit();
+                    </script>
+                </body>
+            </html>
+        '''
+        
+        return make_response(html_content)


### PR DESCRIPTION
This PR is the same as https://github.com/evilsocket/pwnagotchi/pull/1248, which I submitted to the original evilsocket repository. I'm submitting it here too because the original evilsocket repository seems abandoned and aluminum-ice is actually the fork I use daily in my pwnagotchi.

## Description
This PR is a nearly complete rewrite of the wpa-sec plugin to add features and fix bugs.
Below I try to summarize my changes by dividing them into subchapters.

### Uploading handshakes and tracking their status
The most notable improvement brought by this PR is definitely the drastic increase in handshakes that are actually uploaded to the wpa-sec website.

There are several reasons why a handshake may be invalid and therefore rejected by the wpa-sec website, including:
- too much distance from the clients did not allow to capture all the packets needed to crack the handshake;
- the uploaded pcap file was not yet completed, for example because the pwnagotchi had started writing it when it sent the association frame to the AP but the AP had never responded with the PMKID.

The wpa-sec plugin implementation prior to this PR, uploaded any pcap file contained in the handshakes folder (even if its capture was not completed or if the file was still being written) and did not check the response from the wpa-sec website. If an invalid handshake was uploaded, it was still marked as reported by the plugin and was not retried in subsequent captures.
Additionally, this approach suffered from performance and reliability issues:
- as the number of pcap files in the handshakes folder increased, it became longer and longer to iterate
- the list of handshakes already uploaded was saved in a json file. This list was loaded into memory, so it took up more and more RAM as the number of handshakes increased. If pwnagotchi was turned off during writing, the json file was irreparably corrupted.

This PR instead uses a sqlite db to store the status of uploads, which should be a better choice from the point of view of performance, memory usage, and reliability.
Files are added to the database with status `TOUPLOAD` only when pwnagotchi calls the `on_handshake` function, that is, when it is guaranteed that a handshake has been captured and that writing to the pcap file has finished.
When there is an internet connection, all files with status `TOUPLOAD` are uploaded and the response of the wpa-sec API is checked. If a handshake is rejected by the website, it is marked with status `INVALID` and at the next capture it is set back to `TOUPLOAD` so it will be retried.

### Download cracked passwords into .pcap.cracked single files
The new `single_files` option is implemented in the `config.toml` file. This option (which already existed for the Onlinehashcrack plugin), if set to `true`, downloads the cracked passwords from the wpasec website into individual files with the `.pcap.cracked` extension, so you can see the cracked WiFi passwords directly in the webgpsmap plugin map.

### Download interval
This option was implemented by the commit aluminum-ice@b1343b2 and allows you to decide how often to download passwords cracked by wpa-sec. I have adjusted the implementation to make it falls back to the default value of 3600 without crashing the plugin if the option is not set in the `config.toml` file.

### On_webook
The previous implementation of the `on_webhook` function before this commit was broken. When clicking the plugin name in the Plugins tab of the pwnagotchi web UI, you were not actually authenticated to the wpa-sec website, because the code was trying to set the cookie containing the API key on the remote website's origin, so it was obviously not allowed to create cookies due to the Same Origin Policy. The new code implemented by this commit actually authenticates to the wpa-sec website by simulating entering the API key in the website's login form.

### Log messages and exception handling
While rewriting the code I improved the log messages and exception handling (for example, by using the `logging.exception()` method, which prints the exception stacktrace to the logs for easier debugging). Also, this plugin now writes a logging info every time it uploads an handshake to the wpa-sec website, because in my opinion this is a sensitive operation and should be logged.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I noticed that most of my handshakes were not listed in the "My Nets" list on the wpa-sec website, so I started investigating why. I eventually found that invalid handshakes were considered reported and were not retried even if a valid handshake was captured for the same AP later.

<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md)) --> About downloading cracked passwords from wpa-sec website into single `.pcap.cracked` files, please look at [this issue](https://github.com/evilsocket/pwnagotchi/issues/651#issuecomment-608419884) from 2020. For everything else, I haven't opened any issues.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have reread the code multiple times and asked a couple of friends for a review. The code has been running on our pwnagotchi instances without any issues for over three weeks. Unfortunately, I have not done any further testing. If you have any suggestions for further testing, please let me know.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change) --> I paid special attention to backwards compatibility. The plugin does not crash even if the new options in the `config.toml` file are missing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation. --> Maybe? The new `single_files` and `download_interval` options should be documented, but I see that, for example, the onlinehashcrack plugin's `single_files` option was not documented either.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`