### PR TITLE
fixed bettercap in builder script

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -329,7 +329,7 @@
     when: golang.changed
 
   - name: Install bettercap v2.32
-    shell: "export GOPATH=$HOME/go && export PATH=/usr/local/go/bin:$PATH:$GOPATH/bin && go env -w GO111MODULE=off && go get github.com/bettercap/bettercap && cd $GOPATH/src/github.com/bettercap/bettercap && make build && make install"
+    shell: "export GOPATH=$HOME/go && export PATH=/usr/local/go/bin:$PATH:$GOPATH/bin && go install github.com/bettercap/bettercap@latest"
     args:
       executable: /bin/bash
     register: bettercap


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
removed go env -w GO111MODULE=off it was useless
go get is unsupported and replaced with go install
with go install replacing it we do not need to cd into the dir to compile it anymore

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
it fixes the compiling of the image to flash 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ive forked this repo and got gh actions to compile it doesn't affect anything else
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
