### PR TITLE
Phase 1.5: remove orphaned peer/inbox voice methods

### DIFF
--- a/pwnagotchi/ui/hw/base.py
+++ b/pwnagotchi/ui/hw/base.py
@@ -17,8 +17,6 @@ class DisplayImpl(object):
             'uptime': (0, 0),
             'line1': (0, 0),
             'line2': (0, 0),
-            'friend_face': (0, 0),
-            'friend_name': (0, 0),
             'shakes': (0, 0),
             'mode': (0, 0),
             # status is special :D

--- a/pwnagotchi/ui/hw/dfrobot1.py
+++ b/pwnagotchi/ui/hw/dfrobot1.py
@@ -19,8 +19,6 @@ class DFRobotV1(DisplayImpl):
     self._layout['uptime'] = (185, 0)
     self._layout['line1'] = [0, 14, 250, 14]
     self._layout['line2'] = [0, 108, 250, 108]
-    self._layout['friend_face'] = (0, 92)
-    self._layout['friend_name'] = (40, 94)
     self._layout['shakes'] = (0, 109)
     self._layout['mode'] = (225, 109)
     self._layout['status'] = {

--- a/pwnagotchi/ui/hw/dfrobot2.py
+++ b/pwnagotchi/ui/hw/dfrobot2.py
@@ -19,8 +19,6 @@ class DFRobotV2(DisplayImpl):
     self._layout['uptime'] = (185, 0)
     self._layout['line1'] = [0, 14, 250, 14]
     self._layout['line2'] = [0, 108, 250, 108]
-    self._layout['friend_face'] = (0, 92)
-    self._layout['friend_name'] = (40, 94)
     self._layout['shakes'] = (0, 109)
     self._layout['mode'] = (225, 109)
     self._layout['status'] = {

--- a/pwnagotchi/ui/hw/displayhatmini.py
+++ b/pwnagotchi/ui/hw/displayhatmini.py
@@ -20,8 +20,6 @@ class DisplayHatMini(DisplayImpl):
         self._layout['uptime'] = (240, 0)
         self._layout['line1'] = [0, 14, 320, 14]
         self._layout['line2'] = [0, 220, 320, 220]
-        self._layout['friend_face'] = (0, 130)
-        self._layout['friend_name'] = (40, 135)
         self._layout['shakes'] = (0, 220)
         self._layout['mode'] = (280, 220)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/inky.py
+++ b/pwnagotchi/ui/hw/inky.py
@@ -20,8 +20,6 @@ class Inky(DisplayImpl):
         self._layout['uptime'] = (147, 0)
         self._layout['line1'] = [0, 12, 212, 12]
         self._layout['line2'] = [0, 92, 212, 92]
-        self._layout['friend_face'] = (0, 76)
-        self._layout['friend_name'] = (40, 78)
         self._layout['shakes'] = (0, 93)
         self._layout['mode'] = (187, 93)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/lcdhat.py
+++ b/pwnagotchi/ui/hw/lcdhat.py
@@ -20,8 +20,6 @@ class LcdHat(DisplayImpl):
         self._layout['uptime'] = (175, 0)
         self._layout['line1'] = [0, 14, 240, 14]
         self._layout['line2'] = [0, 108, 240, 108]
-        self._layout['friend_face'] = (0, 92)
-        self._layout['friend_name'] = (40, 94)
         self._layout['shakes'] = (0, 109)
         self._layout['mode'] = (215, 109)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/oledhat.py
+++ b/pwnagotchi/ui/hw/oledhat.py
@@ -20,8 +20,6 @@ class OledHat(DisplayImpl):
         self._layout['uptime'] = (87, 0)
         self._layout['line1'] = [0, 9, 128, 9]
         self._layout['line2'] = [0, 54, 128, 54]
-        self._layout['friend_face'] = (0, 41)
-        self._layout['friend_name'] = (40, 43)
         self._layout['shakes'] = (0, 55)
         self._layout['mode'] = (107, 10)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/papirus.py
+++ b/pwnagotchi/ui/hw/papirus.py
@@ -21,8 +21,6 @@ class Papirus(DisplayImpl):
         self._layout['uptime'] = (135, 0)
         self._layout['line1'] = [0, 11, 200, 11]
         self._layout['line2'] = [0, 85, 200, 85]
-        self._layout['friend_face'] = (0, 69)
-        self._layout['friend_name'] = (40, 71)
         self._layout['shakes'] = (0, 86)
         self._layout['mode'] = (175, 86)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/spotpear24inch.py
+++ b/pwnagotchi/ui/hw/spotpear24inch.py
@@ -21,8 +21,6 @@ class Spotpear24inch(DisplayImpl):
         self._layout['uptime'] = (240, 0)
         self._layout['line1'] = [0, 14, 320, 14]
         self._layout['line2'] = [0, 220, 320, 220]
-        self._layout['friend_face'] = (0, 130)
-        self._layout['friend_name'] = (40, 135)
         self._layout['shakes'] = (0, 220)
         self._layout['mode'] = (280, 220)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare1.py
+++ b/pwnagotchi/ui/hw/waveshare1.py
@@ -21,8 +21,6 @@ class WaveshareV1(DisplayImpl):
             self._layout['uptime'] = (185, 0)
             self._layout['line1'] = [0, 14, 250, 14]
             self._layout['line2'] = [0, 108, 250, 108]
-            self._layout['friend_face'] = (0, 92)
-            self._layout['friend_name'] = (40, 94)
             self._layout['shakes'] = (0, 109)
             self._layout['mode'] = (225, 109)
             self._layout['status'] = {
@@ -41,8 +39,6 @@ class WaveshareV1(DisplayImpl):
             self._layout['uptime'] = (147, 0)
             self._layout['line1'] = [0, 12, 212, 12]
             self._layout['line2'] = [0, 92, 212, 92]
-            self._layout['friend_face'] = (0, 76)
-            self._layout['friend_name'] = (40, 78)
             self._layout['shakes'] = (0, 93)
             self._layout['mode'] = (187, 93)
             self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare144lcd.py
+++ b/pwnagotchi/ui/hw/waveshare144lcd.py
@@ -20,8 +20,6 @@ class Waveshare144lcd(DisplayImpl):
         self._layout['uptime'] = (0, 25)
         self._layout['line1'] = [0, 12, 127, 12]
         self._layout['line2'] = [0, 116, 127, 116]
-        self._layout['friend_face'] = (12, 88)
-        self._layout['friend_name'] = (1, 103)
         self._layout['shakes'] = (26, 117)
         self._layout['mode'] = (0, 117)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare154inch.py
+++ b/pwnagotchi/ui/hw/waveshare154inch.py
@@ -20,8 +20,6 @@ class Waveshare154inch(DisplayImpl):
         self._layout['uptime'] = (135, 0)
         self._layout['line1'] = [0, 14, 200, 14]
         self._layout['line2'] = [0, 186, 200, 186]
-        self._layout['friend_face'] = (0, 92)
-        self._layout['friend_name'] = (40, 94)
         self._layout['shakes'] = (0, 187)
         self._layout['mode'] = (170, 187)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare2.py
+++ b/pwnagotchi/ui/hw/waveshare2.py
@@ -21,8 +21,6 @@ class WaveshareV2(DisplayImpl):
             self._layout['uptime'] = (185, 0)
             self._layout['line1'] = [0, 14, 250, 14]
             self._layout['line2'] = [0, 108, 250, 108]
-            self._layout['friend_face'] = (0, 92)
-            self._layout['friend_name'] = (40, 94)
             self._layout['shakes'] = (0, 109)
             self._layout['mode'] = (225, 109)
             self._layout['status'] = {
@@ -42,8 +40,6 @@ class WaveshareV2(DisplayImpl):
             self._layout['uptime'] = (147, 0)
             self._layout['line1'] = [0, 12, 212, 12]
             self._layout['line2'] = [0, 92, 212, 92]
-            self._layout['friend_face'] = (0, 76)
-            self._layout['friend_name'] = (40, 78)
             self._layout['shakes'] = (0, 93)
             self._layout['mode'] = (187, 93)
             self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare213bc.py
+++ b/pwnagotchi/ui/hw/waveshare213bc.py
@@ -20,8 +20,6 @@ class Waveshare213bc(DisplayImpl):
         self._layout['uptime'] = (147, 0)
         self._layout['line1'] = [0, 12, 212, 12]
         self._layout['line2'] = [0, 92, 212, 92]
-        self._layout['friend_face'] = (0, 76)
-        self._layout['friend_name'] = (40, 78)
         self._layout['shakes'] = (0, 93)
         self._layout['mode'] = (187, 93)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare213d.py
+++ b/pwnagotchi/ui/hw/waveshare213d.py
@@ -20,8 +20,6 @@ class Waveshare213d(DisplayImpl):
         self._layout['uptime'] = (147, 0)
         self._layout['line1'] = [0, 12, 212, 12]
         self._layout['line2'] = [0, 92, 212, 92]
-        self._layout['friend_face'] = (0, 76)
-        self._layout['friend_name'] = (40, 78)
         self._layout['shakes'] = (0, 93)
         self._layout['mode'] = (187, 93)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare213g.py
+++ b/pwnagotchi/ui/hw/waveshare213g.py
@@ -20,8 +20,6 @@ class Waveshare213g(DisplayImpl):
         self._layout['uptime'] = (185, 0)
         self._layout['line1'] = [0, 14, 250, 14]
         self._layout['line2'] = [0, 108, 250, 108]
-        self._layout['friend_face'] = (0, 92)
-        self._layout['friend_name'] = (40, 94)
         self._layout['shakes'] = (0, 109)
         self._layout['mode'] = (225, 109)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare213inb_v4.py
+++ b/pwnagotchi/ui/hw/waveshare213inb_v4.py
@@ -21,8 +21,6 @@ class Waveshare213bV4(DisplayImpl):
             self._layout['uptime'] = (185, 0)
             self._layout['line1'] = [0, 14, 250, 14]
             self._layout['line2'] = [0, 108, 250, 108]
-            self._layout['friend_face'] = (0, 92)
-            self._layout['friend_name'] = (40, 94)
             self._layout['shakes'] = (0, 109)
             self._layout['mode'] = (225, 109)
             self._layout['status'] = {
@@ -42,8 +40,6 @@ class Waveshare213bV4(DisplayImpl):
             self._layout['uptime'] = (147, 0)
             self._layout['line1'] = [0, 12, 212, 12]
             self._layout['line2'] = [0, 92, 212, 92]
-            self._layout['friend_face'] = (0, 76)
-            self._layout['friend_name'] = (40, 78)
             self._layout['shakes'] = (0, 93)
             self._layout['mode'] = (187, 93)
             self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare27inch.py
+++ b/pwnagotchi/ui/hw/waveshare27inch.py
@@ -20,8 +20,6 @@ class Waveshare27inch(DisplayImpl):
         self._layout['uptime'] = (199, 0)
         self._layout['line1'] = [0, 14, 264, 14]
         self._layout['line2'] = [0, 162, 264, 162]
-        self._layout['friend_face'] = (0, 146)
-        self._layout['friend_name'] = (40, 146)
         self._layout['shakes'] = (0, 163)
         self._layout['mode'] = (239, 163)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare27inchv2.py
+++ b/pwnagotchi/ui/hw/waveshare27inchv2.py
@@ -20,8 +20,6 @@ class Waveshare27inchV2(DisplayImpl):
         self._layout['uptime'] = (199, 0)
         self._layout['line1'] = [0, 14, 264, 14]
         self._layout['line2'] = [0, 162, 264, 162]
-        self._layout['friend_face'] = (0, 146)
-        self._layout['friend_name'] = (40, 146)
         self._layout['shakes'] = (0, 163)
         self._layout['mode'] = (239, 163)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare29inch.py
+++ b/pwnagotchi/ui/hw/waveshare29inch.py
@@ -20,8 +20,6 @@ class Waveshare29inch(DisplayImpl):
         self._layout['uptime'] = (230, 0)
         self._layout['line1'] = [0, 14, 296, 14]
         self._layout['line2'] = [0, 112, 296, 112]
-        self._layout['friend_face'] = (0, 96)
-        self._layout['friend_name'] = (40, 96)
         self._layout['shakes'] = (0, 114)
         self._layout['mode'] = (268, 114)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare3.py
+++ b/pwnagotchi/ui/hw/waveshare3.py
@@ -20,8 +20,6 @@ class WaveshareV3(DisplayImpl):
         self._layout['uptime'] = (185, 0)
         self._layout['line1'] = [0, 14, 250, 14]
         self._layout['line2'] = [0, 108, 250, 108]
-        self._layout['friend_face'] = (0, 92)
-        self._layout['friend_name'] = (40, 94)
         self._layout['shakes'] = (0, 109)
         self._layout['mode'] = (225, 109)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare35lcd.py
+++ b/pwnagotchi/ui/hw/waveshare35lcd.py
@@ -21,8 +21,6 @@ class Waveshare35lcd(DisplayImpl):
         self._layout['uptime'] = (400, 0)
         self._layout['line1'] = [0, 14, 480, 14]
         self._layout['line2'] = [0,300, 480, 300]
-        self._layout['friend_face'] = (0, 220)
-        self._layout['friend_name'] = (50, 225)
         self._layout['shakes'] = (10, 300)
         self._layout['mode'] = (440, 300)
         self._layout['status'] = {

--- a/pwnagotchi/ui/hw/waveshare4.py
+++ b/pwnagotchi/ui/hw/waveshare4.py
@@ -20,8 +20,6 @@ class WaveshareV4(DisplayImpl):
         self._layout['uptime'] = (185, 0)
         self._layout['line1'] = [0, 14, 250, 14]
         self._layout['line2'] = [0, 108, 250, 108]
-        self._layout['friend_face'] = (0, 92)
-        self._layout['friend_name'] = (40, 94)
         self._layout['shakes'] = (0, 109)
         self._layout['mode'] = (225, 109)
         self._layout['status'] = {

--- a/pwnagotchi/voice.py
+++ b/pwnagotchi/voice.py
@@ -82,21 +82,6 @@ class Voice:
             self._('I\'m having so much fun!'),
             self._('My crime is that of curiosity ...')])
 
-    def on_new_peer(self, peer):
-        if peer.first_encounter():
-            return random.choice([
-                self._('Hello {name}! Nice to meet you.').format(name=peer.name())])
-        else:
-            return random.choice([
-                self._('Yo {name}! Sup?').format(name=peer.name()),
-                self._('Hey {name} how are you doing?').format(name=peer.name()),
-                self._('Unit {name} is nearby!').format(name=peer.name())])
-
-    def on_lost_peer(self, peer):
-        return random.choice([
-            self._('Uhm ... goodbye {name}').format(name=peer.name()),
-            self._('{name} is gone ...').format(name=peer.name())])
-
     def on_miss(self, who):
         return random.choice([
             self._('Whoops ... {name} is gone.').format(name=who),
@@ -151,10 +136,6 @@ class Voice:
     def on_handshakes(self, new_shakes):
         s = 's' if new_shakes > 1 else ''
         return self._('Cool, we got {num} new handshake{plural}!').format(num=new_shakes, plural=s)
-
-    def on_unread_messages(self, count, total):
-        s = 's' if count > 1 else ''
-        return self._('You have {count} new message{plural}!').format(count=count, plural=s)
 
     def on_rebooting(self):
         return self._("Oops, something went wrong ... Rebooting ...")


### PR DESCRIPTION
Delete on_new_peer, on_lost_peer, and on_unread_messages from
pwnagotchi/voice.py. These methods became dead code in Phase 1 when
their only callers (View.on_new_peer / on_lost_peer / on_unread_messages
and the pwngrid peer/inbox flow) were removed.

i18n catalogue regeneration (scripts/language.sh update + make langs) is
deferred: the gettext toolchain (xgettext/msgmerge/msgfmt) is unavailable
in this environment and, per docs/design.md Section 4.1, must be run in
the Pi/builder environment to mark the now-unused strings obsolete.

https://claude.ai/code/session_01PFJ8CmK7Ukxs5JnYoS1zvJ
Signed-off-by: Claude <noreply@anthropic.com>